### PR TITLE
Add a history bridge

### DIFF
--- a/history.rb
+++ b/history.rb
@@ -31,18 +31,19 @@ module Sensu::Extension
     end
 
     def run(event_data)
-      if event_data[:check][:type] == 'metric' then
+      if event_data[:check][:type] != 'check' then
         yield '', 0
+        return
       end
 
       host = event_data[:client][:name].split('.')[0]
       metric = event_data[:check][:name]
       timestamp = event_data[:check][:executed]
       value = if event_data[:check][:status] == 0 then 1 else 0 end
-      output = "sensu.#{host}.checks.#{metric} #{value} #{timestamp}"
+      output = "sensu.#{host}.checks.#{metric} value=#{value} #{timestamp}"
 
       @relay.push(@influx_conf['database'], @influx_conf['time_precision'], output)
-      yield '', 0
+      yield output, 0
     end
 
     def stop

--- a/history.rb
+++ b/history.rb
@@ -1,0 +1,79 @@
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'em-http-request'
+require 'eventmachine'
+require 'multi_json'
+
+module Sensu::Extension
+  class History < Bridge
+    def name
+      definition[:name]
+    end
+
+    def definition
+      {
+        type: 'extension',
+        name: 'history'
+      }
+    end
+
+    def description
+      'Sends check result data to influxdb'
+    end
+
+    def post_init()
+      @influx_conf = parse_settings
+      logger.info("InfluxDB history extension initialiazed using #{@influx_conf['protocol'] }://#{ @influx_conf['host'] }:#{ @influx_conf['port'] } - Defaults : db=#{@influx_conf['database']} precision=#{@influx_conf['time_precision']}")
+
+      @relay = InfluxRelay.new
+      @relay.init(@influx_conf)
+
+      logger.info("History write buffer initiliazed : buffer flushed every #{@influx_conf['buffer_max_size']} points OR every #{@influx_conf['buffer_max_age']} seconds) ")
+    end
+
+    def run(event_data)
+      if event_data[:check][:type] == 'metric' then
+        yield '', 0
+      end
+
+      host = event_data[:client][:name].split('.')[0]
+      metric = event_data[:check][:name]
+      timestamp = event_data[:check][:executed]
+      value = if event_data[:check][:status] == 0 then 1 else 0 end
+      output = "sensu.#{host}.checks.#{metric} #{value} #{timestamp}"
+
+      @relay.push(@influx_conf['database'], @influx_conf['time_precision'], output)
+      yield '', 0
+    end
+
+    def stop
+      logger.info('Flushing history buffer before exiting')
+      @relay.flush_buffer
+      true
+    end
+
+    private
+
+    def parse_settings()
+      begin
+        settings = @settings['history']
+
+        # default values
+        settings['tags'] ||= {}
+        settings['use_ssl'] ||= false
+        settings['time_precision'] ||= 's'
+        settings['protocol'] = settings['use_ssl'] ? 'https' : 'http'
+        settings['buffer_max_size'] ||= 500
+        settings['buffer_max_age'] ||= 6 # seconds
+        settings['port'] ||= 8086
+
+      rescue => e
+        logger.error("Failed to parse History settings #{e}")
+      end
+      return settings
+    end
+
+    def logger
+      Sensu::Logger.get
+    end
+  end
+end

--- a/lib/influx_relay.rb
+++ b/lib/influx_relay.rb
@@ -15,7 +15,6 @@ module Sensu::Extension
     end
 
     def flush_buffer
-      @flush_timer.cancel
       @buffer.each do |db, tp|
         tp.each do |p, points|
           EventMachine::HttpRequest.new("#{ @influx_conf['protocol'] }://#{ @influx_conf['host'] }:#{ @influx_conf['port'] }/write?db=#{ db }&precision=#{ p }&u=#{ @influx_conf['username'] }&p=#{ @influx_conf['password'] }").post :body => points.join("\n")

--- a/lib/influx_relay.rb
+++ b/lib/influx_relay.rb
@@ -1,0 +1,40 @@
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'em-http-request'
+require 'eventmachine'
+
+module Sensu::Extension
+  class InfluxRelay
+    def init(config)
+      @influx_conf = config
+      @buffer = {}
+      @flush_timer = EventMachine::PeriodicTimer.new(@influx_conf['buffer_max_age'].to_i) do
+        unless buffer_size == 0
+          flush_buffer
+        end
+      end
+    end
+
+    def flush_buffer
+      @flush_timer.cancel
+      @buffer.each do |db, tp|
+        tp.each do |p, points|
+          EventMachine::HttpRequest.new("#{ @influx_conf['protocol'] }://#{ @influx_conf['host'] }:#{ @influx_conf['port'] }/write?db=#{ db }&precision=#{ p }&u=#{ @influx_conf['username'] }&p=#{ @influx_conf['password'] }").post :body => points.join("\n")
+        end
+        @buffer[db] = {}
+      end
+    end
+
+    def buffer_size
+      sum = @buffer.map { |_db, tp| tp.map { |_p, points| points.length}.inject(:+) }.inject(:+)
+      return sum || 0
+    end
+
+    def push(database, time_precision, data)
+      @buffer[database] ||= {}
+      @buffer[database][time_precision] ||= []
+
+      @buffer[database][time_precision].push(data)
+      flush_buffer if buffer_size >= @influx_conf['buffer_max_size']
+    end
+  end
+end


### PR DESCRIPTION
A "bridge" is a sensu concept (like handlers, mutators, etc) for sending data to an external system.

In this case we're using it to handle check-result data and saving it to influxdb, so that we can calculate a percentage value for the check being red or green.

I've refactored the influxdb plugin as well so that the code for buffering and flushing to influx can be shared between the different extensions