### PR TITLE
specify a prefix for history measurements

### DIFF
--- a/history.rb
+++ b/history.rb
@@ -40,7 +40,7 @@ module Sensu::Extension
       metric = event_data[:check][:name]
       timestamp = event_data[:check][:executed]
       value = if event_data[:check][:status] == 0 then 1 else 0 end
-      output = "sensu.#{host}.checks.#{metric} value=#{value} #{timestamp}"
+      output = "#{@influx_conf['scheme']}.#{host}.checks.#{metric} value=#{value} #{timestamp}"
 
       @relay.push(@influx_conf['database'], @influx_conf['time_precision'], output)
       yield output, 0
@@ -66,6 +66,7 @@ module Sensu::Extension
         settings['buffer_max_size'] ||= 500
         settings['buffer_max_age'] ||= 6 # seconds
         settings['port'] ||= 8086
+        settings['scheme'] ||= 'sensu'
 
       rescue => e
         logger.error("Failed to parse History settings #{e}")


### PR DESCRIPTION
allows you to give a prefix to history measurements, default is `sensu`:

`sensu.myhost.checks.check-load value=1 1456783456`

or

`foo.bar.myhost.checks.check-load value=1  1456783456`

in the config use:

```
{
  "history": {
    ...
    "scheme": "foo.bar"
  }
}